### PR TITLE
Disable non-defined ssl cert

### DIFF
--- a/k8s/charts/nginx-ingress/values.yml
+++ b/k8s/charts/nginx-ingress/values.yml
@@ -184,8 +184,9 @@ controller:
   maxmindLicenseKey: ""
   # -- Additional command line arguments to pass to Ingress-Nginx Controller
   # E.g. to specify the default SSL certificate you can use
-  extraArgs:
-    default-ssl-certificate: ""
+  extraArgs: {}
+  ## extraArgs:
+  ##   default-ssl-certificate: "<namespace>/<secret_name>"
   ##   time-buckets: "0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10"
   ##   length-buckets: "10,20,30,40,50,60,70,80,90,100"
   ##   size-buckets: "10,100,1000,10000,100000,1e+06,1e+07"


### PR DESCRIPTION
Resolved failing pod
```
Back-off restarting failed container controller in pod gamesingress-ingress-nginx-controller-swkrl_games-ns(b0914bc3-5885-4708-abfc-19fe60d0ef92)
```

Due to enabled default-ssl without specifying certs, which makes the pod fail to start with this log error
```
flag needs an argument: --default-ssl-certificate
```