### PR TITLE
Disable runner labels

### DIFF
--- a/terraform/k3s-utils/runners/main.tf
+++ b/terraform/k3s-utils/runners/main.tf
@@ -15,11 +15,12 @@ resource "helm_release" "gha_runners" {
   }
   # This comment helped me tremendously in properly passing YAML list attributes from TF:
   # https://github.com/hashicorp/terraform-provider-helm/issues/1022#issuecomment-1370071345
-  values = [
-    yamlencode({
-      gloab = {
-        labels = "k3s_utils"
-      }
-    })
-  ]
+  # TODO: this is broken, needs to be fixed. Use default GHA runner label "self-hosted"
+  #   values = [
+  #     yamlencode({
+  #       gloab = {
+  #         labels = "k3s_utils"
+  #       }
+  #     })
+  #   ]
 }


### PR DESCRIPTION
Yaml values parsing is still not working properly. Disabled for now, and will rely on default label `self-hosted`.