### PR TITLE
MetalLB chart and CRDs

### DIFF
--- a/terraform/k3s-main/gha-cicd/outputs.tf
+++ b/terraform/k3s-main/gha-cicd/outputs.tf
@@ -7,7 +7,7 @@ kind: Config
 clusters:
 - name: k3s-main
   cluster:
-    server: "https://${var.control_plane_ipv4}:6443"
+    server: "https://${var.k3s_main_control_plane_ipv4}:6443"
     certificate-authority-data: ${base64encode(kubernetes_secret_v1.gha_token.data["ca.crt"])}
 users:
 - name: gha-runner

--- a/terraform/k3s-main/gha-cicd/variables.tf
+++ b/terraform/k3s-main/gha-cicd/variables.tf
@@ -15,7 +15,7 @@ variable "kube_namespace" {
   description = "Namespace where the gha-runner service account will reside (typically 'cicd')"
 }
 
-variable "control_plane_ipv4" {
+variable "k3s_main_control_plane_ipv4" {
   type        = string
   description = "Control plane IP or DNS"
 }

--- a/terraform/k3s-utils/metallb-crd/main.tf
+++ b/terraform/k3s-utils/metallb-crd/main.tf
@@ -1,0 +1,29 @@
+resource "kubernetes_manifest" "ip_address_pool" {
+  manifest = {
+    apiVersion = "metallb.io/v1beta1"
+    kind       = "IPAddressPool"
+    metadata = {
+      name      = var.ipv4_address_pool_name
+      namespace = var.kube_namespace
+    }
+    spec = {
+      addresses = var.ipv4_address_pool
+    }
+  }
+}
+
+resource "kubernetes_manifest" "l2_advertisement" {
+  manifest = {
+    apiVersion = "metallb.io/v1beta1"
+    kind       = "L2Advertisement"
+    metadata = {
+      name      = "main-advertisement"
+      namespace = var.kube_namespace
+    }
+    spec = {
+      ipAddressPools = [var.ipv4_address_pool_name]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.ip_address_pool]
+}

--- a/terraform/k3s-utils/metallb-crd/providers.tf
+++ b/terraform/k3s-utils/metallb-crd/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  backend "s3" {
+    region = "us-east-1"
+    key    = "metallb_crd-k3s_utils-state"
+  }
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.36.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kube_config_path
+}

--- a/terraform/k3s-utils/metallb-crd/variables.tf
+++ b/terraform/k3s-utils/metallb-crd/variables.tf
@@ -1,0 +1,24 @@
+
+variable "ipv4_address_pool_name" {
+  type        = string
+  default     = "default-pool"
+  description = "IP addresses pool name. This name will be used in the `L2Advertisement.spec.IPAddressPool` K8s CRD. This is important because if omitted, MetalLB will advertise from any available IP pool in the namespace."
+}
+
+variable "ipv4_address_pool" {
+  type        = list(string)
+  default     = ["10.10.50.90-10.10.50.99"]
+  description = "To generate an address pool. An *address pool* is one or more IPv4 range. This variable is a list of strings for the IPv4 *ranges* that MetalLB will use when provisioning a Service of type LoadBalance. Example values: `['192.168.50.90-192.168.50.99', '192.168.20.45-192.168.20.60']`"
+}
+
+variable "kube_config_path" {
+  default     = "~/.kube/config"
+  type        = string
+  description = "Path to kubeconfig file relative to where this script will run"
+}
+
+variable "kube_namespace" {
+  type        = string
+  default     = "metallb-system"
+  description = "Namespace where the gha-runner service account will reside (typically 'cicd')"
+}

--- a/terraform/k3s-utils/metallb/main.tf
+++ b/terraform/k3s-utils/metallb/main.tf
@@ -1,0 +1,5 @@
+module "metallb" {
+  source          = "../../modules/metallb"
+  release_name    = "metallb"
+  metallb_version = "0.14.5"
+}

--- a/terraform/k3s-utils/metallb/providers.tf
+++ b/terraform/k3s-utils/metallb/providers.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  backend "s3" {
+    region = "us-east-1"
+    key    = "metallb-k3s_utils-state"
+  }
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kube_config_path
+  }
+}

--- a/terraform/k3s-utils/metallb/variables.tf
+++ b/terraform/k3s-utils/metallb/variables.tf
@@ -1,0 +1,5 @@
+variable "kube_config_path" {
+  default     = "~/.kube/config"
+  type        = string
+  description = "Path to kubeconfig file relative to where this script will run"
+}

--- a/terraform/modules/metallb/main.tf
+++ b/terraform/modules/metallb/main.tf
@@ -1,0 +1,58 @@
+/**
+ * ## MetalLB Helm Deployment
+ *
+ * This module installs the official [MetalLB Helm chart](https://metallb.universe.tf/installation/#installation-with-helm)
+ * and configures a simple Layer 2 advertisement with a static IP address pool using Terraform.
+ *
+ * ## Requirements
+ * Set IP address ranges for MetalLB to allocate from when a LoadBalancer Service is deployed;
+ * ensure the range is available in your router - e.g., 192.168.50.90-192.168.50.99 may be reserved
+ * for static mapping.
+ *
+ * ## Usage
+ *
+ * ```hcl
+ * module "metallb" {
+ *   source  = "path/to/this/module"
+ *   # Required variables
+ *   metallb_chart_version = "0.14.5"
+ *   ip_range              = ["10.10.50.90-10.10.50.99"]
+ *   pool_name             = "first-pool"
+ *   advertisement_name    = "main-advertisement"
+ * }
+ * ```
+ *
+ * This will:
+ * - Install the MetalLB Helm chart in the `metallb-system` namespace
+ * - Deploy a `IPAddressPool` CRD
+ * - Deploy a `L2Advertisement` CRD that references the IP pool
+ *
+ * > Note: MetalLB CRDs must be created **after** the Helm chart installation, so this configuration
+ * includes appropriate `depends_on` logic to ensure ordering.
+ */
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+  }
+}
+
+resource "helm_release" "metallb" {
+  name       = var.release_name
+  namespace  = var.kube_namespace
+  repository = "https://metallb.github.io/metallb"
+  chart      = "metallb"
+  version    = var.metallb_version
+
+  create_namespace = true
+
+  values = [
+    yamlencode({
+      configInline = {} # Empty to disable legacy config
+    })
+  ]
+}

--- a/terraform/modules/metallb/outputs.tf
+++ b/terraform/modules/metallb/outputs.tf
@@ -1,0 +1,3 @@
+output "metallb_chart_status" {
+  value = helm_release.metallb.status
+}

--- a/terraform/modules/metallb/variables.tf
+++ b/terraform/modules/metallb/variables.tf
@@ -1,0 +1,17 @@
+variable "release_name" {
+  type        = string
+  default     = "metallb"
+  description = "Helm release name"
+}
+
+variable "kube_namespace" {
+  type        = string
+  default     = "metallb-system"
+  description = "Namespace where MetlLb should be installed. Default to `metallb-system` (this is a standard MetalLb namespace, don't change if you don't know what you're doing!)"
+}
+
+variable "metallb_version" {
+  type        = string
+  default     = "0.14.5"
+  description = "MetlLb version"
+}


### PR DESCRIPTION
This PR adds:
- Terraform module for barebone MetalLB deployment using Helm.
- MetalLB resource deployment (Terraform).
- MetalLB CRDs for IP pool and advertisement (Terraform)
- Adjusts variable name for clarity.