### PR TITLE
Set kube-context as a TF var

### DIFF
--- a/terraform/k3s-main/gha-cicd/outputs.tf
+++ b/terraform/k3s-main/gha-cicd/outputs.tf
@@ -1,3 +1,8 @@
+output "kube_context_in_use" {
+  value       = var.kube_context
+  description = "The kubeconfig context being used by the Kubernetes provider"
+}
+
 output "gha_kubeconfig_snippet" {
   description = "Kubeconfig section for GitHub Actions"
   sensitive   = true

--- a/terraform/k3s-main/gha-cicd/providers.tf
+++ b/terraform/k3s-main/gha-cicd/providers.tf
@@ -16,5 +16,5 @@ terraform {
 
 provider "kubernetes" {
   config_path    = var.kube_config_path
-  config_context = var.cluster_context
+  config_context = var.kube_context
 }

--- a/terraform/k3s-main/gha-cicd/variables.tf
+++ b/terraform/k3s-main/gha-cicd/variables.tf
@@ -1,6 +1,7 @@
-variable "cluster_context" {
-  description = "Kubeconfig context for the target cluster"
+variable "kube_context" {
+  description = "The name of the kubeconfig context to use"
   type        = string
+  default     = "k3s-main-ctx"
 }
 
 variable "kube_config_path" {

--- a/terraform/k3s-utils/cert-manager/providers.tf
+++ b/terraform/k3s-utils/cert-manager/providers.tf
@@ -16,6 +16,7 @@ terraform {
 
 provider "helm" {
   kubernetes {
-    config_path = var.kube_config_path
+    config_path    = var.kube_config_path
+    config_context = var.kube_context
   }
 }

--- a/terraform/k3s-utils/cert-manager/variables.tf
+++ b/terraform/k3s-utils/cert-manager/variables.tf
@@ -4,6 +4,12 @@ variable "kube_config_path" {
   description = "Path to kubeconfig file relative to where this script will run"
 }
 
+variable "kube_context" {
+  description = "The name of the kubeconfig context to use"
+  type        = string
+  default     = "k3s-utils-ctx"
+}
+
 variable "kube_namespace" {
   default     = "cert-manager"
   type        = string

--- a/terraform/k3s-utils/nginx-ingress/main.tf
+++ b/terraform/k3s-utils/nginx-ingress/main.tf
@@ -13,3 +13,8 @@ resource "helm_release" "ingress_nginx" {
     file("../../../k8s/charts/nginx-ingress/values.yml")
   ]
 }
+
+output "kube_context_in_use" {
+  value       = var.kube_context
+  description = "The kubeconfig context being used by the Kubernetes provider"
+}

--- a/terraform/k3s-utils/nginx-ingress/providers.tf
+++ b/terraform/k3s-utils/nginx-ingress/providers.tf
@@ -20,10 +20,12 @@ terraform {
 
 provider "helm" {
   kubernetes {
-    config_path = var.kube_config_path
+    config_path    = var.kube_config_path
+    config_context = var.kube_context
   }
 }
 
 provider "kubernetes" {
-  config_path = var.kube_config_path
+  config_path    = var.kube_config_path
+  config_context = var.kube_context
 }

--- a/terraform/k3s-utils/nginx-ingress/variables.tf
+++ b/terraform/k3s-utils/nginx-ingress/variables.tf
@@ -4,6 +4,12 @@ variable "kube_config_path" {
   description = "Path to kubeconfig file relative to where this script will run"
 }
 
+variable "kube_context" {
+  description = "The name of the kubeconfig context to use"
+  type        = string
+  default     = "k3s-utils-ctx"
+}
+
 variable "kube_namespace" {
   default     = "ingress"
   type        = string

--- a/terraform/k3s-utils/runners/main.tf
+++ b/terraform/k3s-utils/runners/main.tf
@@ -24,3 +24,8 @@ resource "helm_release" "gha_runners" {
   #     })
   #   ]
 }
+
+output "kube_context_in_use" {
+  value       = var.kube_context
+  description = "The kubeconfig context being used by the Kubernetes provider"
+}

--- a/terraform/k3s-utils/runners/providers.tf
+++ b/terraform/k3s-utils/runners/providers.tf
@@ -16,6 +16,7 @@ terraform {
 
 provider "helm" {
   kubernetes {
-    config_path = var.kube_config_path
+    config_path    = var.kube_config_path
+    config_context = var.kube_context
   }
 }

--- a/terraform/k3s-utils/runners/variables.tf
+++ b/terraform/k3s-utils/runners/variables.tf
@@ -4,6 +4,12 @@ variable "kube_config_path" {
   description = "Path to kubeconfig file relative to where this script will run"
 }
 
+variable "kube_context" {
+  description = "The name of the kubeconfig context to use"
+  type        = string
+  default     = "k3s-utils-ctx"
+}
+
 variable "gha_runner_name" {
   default     = "tf-runners-k3s"
   type        = string


### PR DESCRIPTION
This PR sets the kube context as a tf var for all k3s projects to avoid constant kube context change from the terminal/pipeline