### PR TITLE
Refactor PVC Chart to Support Single Claim with Multiple Mount Paths

### DIFF
--- a/helm/charts/pvc-storage/README.md
+++ b/helm/charts/pvc-storage/README.md
@@ -1,0 +1,74 @@
+# PVC Helm Module
+
+This Helm module provisions a *single* PersistentVolumeClaim (PVC) and supports mounting it to *multiple paths* within a container using `subPath`.
+
+## What can this chart do?
+
+Creates **only one PVC** regardless of how many mount paths are defined, with:
+- Custom access modes
+- Storage class configuration
+- Labels and annotations
+- Shared volumes (e.g., NFS)
+
+## Values Structure (PVC Chart)
+
+```yaml
+pvc:
+  enabled: true
+  claimName: claim-myapp
+  accessMode: ReadWriteMany
+  storageClassName: nfs-client
+  storage: 5Gi
+  mountPaths:
+    - /data
+    - /config
+  labels:
+    app: myapp
+  annotations:
+    volume.kubernetes.io/description: "Shared PVC for my app"
+```
+
+## Template Highlights
+
+PVC Manifest
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.pvc.claimName }}
+spec:
+  accessModes:
+    - {{ .Values.pvc.accessMode | default "ReadWriteMany" }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.storage | default "1Gi" }}
+  storageClassName: {{ .Values.pvc.storageClassName | default "nfs-client" }}
+```
+
+Deployment Integration (Mounts the same PVC to different paths using `subPath`):
+
+```yaml
+volumeMounts:
+  {{- $claimName := .Values.pvc.claimName }}
+  {{- range .Values.pvc.mountPaths }}
+  - name: {{ $claimName }}
+    mountPath: {{ . }}
+    subPath: {{ trimPrefix "/" . }}
+  {{- end }}
+
+volumes:
+  - name: {{ .Values.pvc.claimName }}
+    persistentVolumeClaim:
+      claimName: {{ .Values.pvc.claimName }}
+```
+
+## Caveats
+
+- `subPath` must be explicitly used to prevent all mount paths from sharing the same PVC root.
+- Subdirectories (data, config, etc.) are created inside the PVC volume automatically on first write, or can be pre-created using an `initContainer`.
+
+## Benefits
+
+- Efficient use of resources: single PVC shared across multiple application paths.
+- Cleaner directory separation within shared volume backends (e.g., NFS).
+- Customizable via Helm values.

--- a/helm/charts/pvc-storage/templates/NOTES.txt
+++ b/helm/charts/pvc-storage/templates/NOTES.txt
@@ -1,39 +1,41 @@
-{{- if and .Values.pvc.mounts }}
+{{- if and .Values.pvc.enabled .Values.pvc.claimName }}
 
-✅ {{ .Chart.Name }} PVCs have been successfully deployed!
+✅ {{ .Chart.Name }} PVC has been successfully deployed!
 
-🔖 Summary of the created PVCs:
+🔖 PVC Details:
 
-{{- range .Values.pvc.mounts }}
-  - Claim Name:  {{ .claimName }}
-    Mount Path:  {{ .mountPath }}
-    Storage:     {{ .storage | default "1Mi" }}
-    AccessMode:  {{ .accessMode | default "ReadWriteMany" }}
-    StorageClass: {{ .storageClassName }}
-{{- $hint := index .annotations "custom.synology/path-hint" }}
+  - Claim Name:   {{ .Values.pvc.claimName }}
+  - Storage:      {{ .Values.pvc.storage | default "1Gi" }}
+  - Access Mode:  {{ .Values.pvc.accessMode | default "ReadWriteMany" }}
+  - Storage Class:{{ .Values.pvc.storageClassName | default "nfs-client" }}
+
+{{- $hint := index .Values.pvc.annotations "custom.synology/path-hint" }}
 {{- if $hint }}
-    NAS Path Hint: {{ $hint }}
-{{- end }}
+  - NAS Path Hint: {{ $hint }}
 {{- end }}
 
-💡 These PVCs are dynamically provisioned using the CSI NFS driver.
-   The actual NFS share directory names will follow the pattern `pvc-<uuid>`.
+💡 This PVC is dynamically provisioned using the CSI NFS driver.
+   The actual NFS share directory will be named like `pvc-<uuid>`.
 
-🧭 Use labels and annotations to track their usage and pod associations.
+🧭 Use labels and annotations to track this volume and its purpose.
 
 {{- else }}
 
-⚠️ No PVCs were created. Either `pvc.mounts` is empty or disabled.
+⚠️ No PVC was created. Either `pvc.enabled` is `false` or `pvc.claimName` is missing.
 
-To create PVCs, make sure to enable them in your values file:
+To create a PVC, your values file should include:
 
   pvc:
-    mounts:
-      - name: pvc-<name>
-        claimName: claim-<name>
-        mountPath: /app/data
-        storageClassName: nfs-client
-        storage: 1Gi
+    enabled: true
+    claimName: app-shared-pvc
+    accessMode: ReadWriteMany
+    storageClassName: nfs-client
+    storage: 5Gi
+    labels:
+      app: my-app
+    annotations:
+      volume.kubernetes.io/description: "Shared volume for app"
+      custom.synology/path-hint: "maps to /vol/k8s/..."
 
 {{- end }}
 

--- a/helm/charts/pvc-storage/templates/pvc.yaml
+++ b/helm/charts/pvc-storage/templates/pvc.yaml
@@ -1,39 +1,20 @@
-{{- define "validate.pvc.mounts" }}
-{{- $claimNames := dict }}
-{{- range .Values.pvc.mounts }}
-  {{- if not .mountPath }}
-    {{- fail (printf "PVC mountPath is required for claimName '%s'" .claimName) }}
-  {{- end }}
-  {{- if hasKey $claimNames .claimName }}
-    {{- fail (printf "Duplicate PVC claimName detected: '%s'" .claimName) }}
-  {{- end }}
-  {{- $_ := set $claimNames .claimName true }}
-{{- end }}
-{{- end }}
-
-{{- if and .Values.pvc.enabled .Values.pvc.mounts }}
-{{- template "validate.pvc.mounts" . }}
-{{- range .Values.pvc.mounts }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .claimName }}
-  namespace: {{ $.Values.namespace | default $.Release.Namespace }}
+  name: {{ .Values.pvc.claimName }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
-    {{- with .labels }}
+    {{- with .Values.pvc.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .annotations }}
+    {{- with .Values.pvc.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   accessModes:
-    - {{ .accessMode | default "ReadWriteMany" }}
+    - {{ .Values.pvc.accessMode | default "ReadWriteMany" }}
   resources:
     requests:
-      storage: {{ .storage | default "1Gi" }}
-  storageClassName: {{ .storageClassName | default "nfs-client" }}
----
-{{- end }}
-{{- end }}
+      storage: {{ .Values.pvc.storage | default "1Gi" }}
+  storageClassName: {{ .Values.pvc.storageClassName | default "nfs-client" }}

--- a/helm/charts/pvc-storage/values.schema.json
+++ b/helm/charts/pvc-storage/values.schema.json
@@ -4,78 +4,63 @@
   "properties": {
     "namespace": {
       "type": "string",
-      "description": "Optional override for the namespace where PVCs will be created."
+      "description": "Optional override for the namespace where the PVC will be created."
     },
     "pvc": {
       "type": "object",
       "required": [
-        "mounts"
+        "claimName"
       ],
       "properties": {
-        "mounts": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "required": [
-              "claimName",
-              "mountPath",
-              "name"
-            ],
-            "properties": {
-              "name": {
-                "type": "string",
-                "pattern": "^pvc-[a-z0-9-]+$",
-                "description": "Name used in volumeMounts/volumes. Must start with 'pvc-'."
-              },
-              "claimName": {
-                "type": "string",
-                "pattern": "^claim-[a-z0-9-]+$",
-                "description": "Name of the PersistentVolumeClaim. Must start with 'claim-'."
-              },
-              "mountPath": {
-                "type": "string",
-                "pattern": "^/.*",
-                "description": "Absolute mount path inside the container."
-              },
-              "accessMode": {
-                "type": "string",
-                "enum": [
-                  "ReadWriteOnce",
-                  "ReadOnlyMany",
-                  "ReadWriteMany"
-                ],
-                "default": "ReadWriteMany",
-                "description": "Kubernetes PVC access mode."
-              },
-              "storageClassName": {
-                "type": "string",
-                "description": "Storage class to use for the PVC."
-              },
-              "storage": {
-                "type": "string",
-                "pattern": "^[0-9]+(Mi|Gi|Ti)$",
-                "default": "1Mi",
-                "description": "Requested storage size (e.g. 1Gi, 10Gi)."
-              },
-              "labels": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Labels to apply to the PVC."
-              },
-              "annotations": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Annotations to apply to the PVC (e.g. custom.synology/path-hint)."
-              }
-            }
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to create the PVC resource."
+        },
+        "claimName": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "description": "Name of the PersistentVolumeClaim."
+        },
+        "accessMode": {
+          "type": "string",
+          "enum": [
+            "ReadWriteOnce",
+            "ReadOnlyMany",
+            "ReadWriteMany"
+          ],
+          "default": "ReadWriteMany",
+          "description": "Kubernetes PVC access mode."
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "Storage class to use for the PVC.",
+          "default": "nfs-client"
+        },
+        "storage": {
+          "type": "string",
+          "pattern": "^[0-9]+(Mi|Gi|Ti)$",
+          "default": "1Gi",
+          "description": "Requested storage size (e.g. 1Gi, 10Gi)."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Labels to apply to the PVC.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to apply to the PVC.",
+          "additionalProperties": {
+            "type": "string"
           }
         }
       }
     }
-  }
+  },
+  "required": [
+    "pvc"
+  ]
 }

--- a/helm/charts/pvc-storage/values.yaml
+++ b/helm/charts/pvc-storage/values.yaml
@@ -1,29 +1,21 @@
 ---
 namespace: ""
 pvc:
-  enabled: true
-  # Replace this map to create additional PVCs.
-  mounts:
-    # PVC object name. This a single claim. Replicate this list if you wish to
-    # mount more than one claim.
-    - name: ""
-      # Will be used in the pvc.yaml and target deployment.yaml
-      claimName: ""
-      # Default mode, can be overriden
-      accessMode: ReadWriteMany
-      # Ensure storage class is provisioned, otherwise PVC will stuck on "pending" status
-      storageClassName: nfs-client
-      # Storage size, e.g. 5Gi. It's a soft condition for non-cloud NFS providers
-      storage: ""
-      # Mount path in the pod
-      mountPath: ""
-      # Use labels and annotations to track what this PVC is for and where it's mounted
-      # Dynamic provisioning via the NFS CSI driver does not allow customizing the directory name
-      # All mount points created in the NFS share will be named like: pvc-<unique-pvc-uid>
-      labels:
-        # You can add more.
-        app: ""
-      annotations:
-        # You can add more. Follow K8s annotation conventions.
-        volume.kubernetes.io/description: "Data volume for app"
-        custom.synology/path-hint: "maps to /vol/k8s/path/whatever/in/you/nas"
+  # PVC object name. should be: vol-xxxxxx
+  name: ""
+  # Will be used in the pvc.yaml and target deployment.yaml. should be claim-xxxxxxx
+  claimName: ""
+  # Default mode, can be overriden
+  accessMode: ReadWriteMany
+  # Ensure storage class is provisioned, otherwise PVC will stuck on "pending" status
+  storageClassName: nfs-client
+  # Storage size, e.g. 5Gi. It's a soft condition for non-cloud NFS providers
+  storage: 5Gi
+  # Use labels and annotations to track what this PVC is for and where it's mounted
+  # Dynamic provisioning via the NFS CSI driver does not allow customizing the directory name
+  # All mount points created in the NFS share will be named like: pvc-<unique-pvc-uid>
+  labels:
+    app: ""
+  annotations:
+    volume.kubernetes.io/description: "Shared volume for app"
+    custom.synology/path-hint: "maps to /vol/k8s/path/whatever/in/you/nas"

--- a/helm/charts/stateless-apps/templates/deployment.yaml
+++ b/helm/charts/stateless-apps/templates/deployment.yaml
@@ -39,16 +39,16 @@ spec:
 
           {{- if .Values.pvc.enabled }}
           volumeMounts:
-            {{- range .Values.pvc.mounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
+            {{- $claimName := .Values.pvc.claimName }}
+            {{- range .Values.pvc.mountPaths }}
+            - name: {{ $claimName }}
+              mountPath: {{ . }}
+              subPath: {{ trimPrefix "/" . }}
             {{- end }}
           {{- end }}
       {{- if .Values.pvc.enabled }}
       volumes:
-        {{- range .Values.pvc.mounts }}
-        - name: {{ .name }}
+        - name: {{ .Values.pvc.claimName }}
           persistentVolumeClaim:
-            claimName: {{ .claimName }}
-        {{- end }}
+            claimName: {{ .Values.pvc.claimName }}
       {{- end }}

--- a/helm/charts/stateless-apps/values.yaml
+++ b/helm/charts/stateless-apps/values.yaml
@@ -42,11 +42,9 @@ livenessProbe:
   failureThreshold: 3
 
 # This chart will not provision a PVC. If the app needs a storage, then a PVC
-# must be up and running before deploying this chart.
+# must be up and running before deploying this chart. This is a single PVC
+# with multiple mount points.
 pvc:
   enabled: false
-  # List of PVC mounts the app needs
-  mounts:
-    # - name: unique-volume-id
-    #   claimName: pvc-name-provisioned-by-storage-chart
-    #   mountPath: /path/in/container
+  claimName: ""
+  mountPaths: []

--- a/helm/values/apps/deemix.yaml
+++ b/helm/values/apps/deemix.yaml
@@ -42,3 +42,10 @@ pvc:
     - name: "vol-deemix-config"
       claimName: "claim-deemix-config"
       mountPath: /config
+
+pvc:
+  enabled: true
+  claimName: claim-deemix
+  mountPaths:
+    - /downloads
+    - /config

--- a/helm/values/pvc/deemix.yaml
+++ b/helm/values/pvc/deemix.yaml
@@ -2,27 +2,13 @@
 namespace: "apps"
 pvc:
   enabled: true
-  mounts:
-    - name: "pvc-deemix-downloads"
-      claimName: "claim-deemix-downloads"
-      accessMode: ReadWriteMany
-      storageClassName: nfs-client
-      storage: "500Mi"
-      mountPath: "/downloads"
-      labels:
-        app: "deemix"
-      annotations:
-        volume.kubernetes.io/description: "Downloads volume for deemix"
-        custom.synology/path-hint: "maps to /volume1/k3s/pvc-<uid>"
-
-    - name: "pvc-deemix-config"
-      claimName: "claim-deemix-config"
-      accessMode: ReadWriteMany
-      storageClassName: nfs-client
-      storage: "500Mi"
-      mountPath: "/config"
-      labels:
-        app: "deemix"
-      annotations:
-        volume.kubernetes.io/description: "Config volume for deemix"
-        custom.synology/path-hint: "maps to /volume1/k3s/pvc-<uid>"
+  name: pvc-deemix
+  claimName: claim-deemix
+  accessMode: ReadWriteMany
+  storageClassName: nfs-client
+  storage: 100Mi
+  labels:
+    app: deemix
+  annotations:
+    volume.kubernetes.io/description: "Shared PVC for deemix"
+    custom.synology/path-hint: "maps to /vol1/k3s/pvc-<uid>"

--- a/helmfile.d/apps-helmfile.yaml.gotmpl
+++ b/helmfile.d/apps-helmfile.yaml.gotmpl
@@ -6,56 +6,8 @@
 {{- $commonNamespace := "apps" -}}
 
 releases:
-  - name: excalidraw
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "excalidraw.yaml" }}
-
-  - name: change-detection
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "change-detection.yaml" }}
-
   - name: deemix
     namespace: {{ $commonNamespace }}
     chart: {{ $statelessChartsDir }}
     values:
       - {{ printf "%s/%s" $valuesDir "deemix.yaml" }}
-
-  - name: homarr
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "homarr.yaml" }}
-
-  - name: metube
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "metube.yaml" }}
-
-  - name: omni-tools
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "omni-tools.yaml" }}
-
-  - name: speedtest
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "speedtest.yaml" }}
-
-  - name: s-pdf
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "s-pdf.yaml" }}
-
-  - name: actualbudget
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "actualbudget.yaml" }}

--- a/helmfile.d/pvc-helmfile.yaml.gotmpl
+++ b/helmfile.d/pvc-helmfile.yaml.gotmpl
@@ -6,44 +6,8 @@
 {{- $commonNamespace := "apps" -}}
 
 releases:
-  - name: pvc-change-detection
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "change-detection.yaml" }}
-
   - name: pvc-deemix
     namespace: {{ $commonNamespace }}
     chart: {{ $statelessChartsDir }}
     values:
       - {{ printf "%s/%s" $valuesDir "deemix.yaml" }}
-
-  - name: pvc-homarr
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "homarr.yaml" }}
-
-  - name: pvc-metube
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "metube.yaml" }}
-
-  - name: pvc-speedtest
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "speedtest.yaml" }}
-
-  - name: pvc-s-pdf
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "s-pdf.yaml" }}
-
-  - name: pvc-actualbudget
-    namespace: {{ $commonNamespace }}
-    chart: {{ $statelessChartsDir }}
-    values:
-      - {{ printf "%s/%s" $valuesDir "actualbudget.yaml" }}


### PR DESCRIPTION
This PR refactors the PVC Helm chart to support provisioning a single PVC that can be mounted at multiple paths within a container.

- Introduced `pvc.mountPaths` to allow multiple mount targets for a single PVC.
- Updated Deployment template to use `subPath` for each mountPath, isolating directory content within the shared volume.
- Simplified PVC creation logic: only one PVC is created based on `pvc.claimName`.
- Updated NOTES.txt and JSON schema to reflect the new configuration structure.


#### Motiviation

Previously, multiple PVCs were created per mountPath, which was inefficient and unnecessary for shared storage scenarios (e.g., cluttered my NFS). This refactor reduces resource usage.

#### Usage Example
```yaml
pvc:
  enabled: true
  claimName: claim-myapp
  mountPaths:
    - /data
    - /config
```