### PR TITLE
Use a fork of Bitnami's mariadb image

### DIFF
--- a/helm/values/apps/gaseous.yaml
+++ b/helm/values/apps/gaseous.yaml
@@ -32,8 +32,8 @@ db:
   host: gsdb
   port: 3306
   image:
-    repository: bitnami/mariadb
-    tag: latest
+    repository: shakir85/bitnami-mariadb
+    tag: 30072025
     pullPolicy: IfNotPresent
   volumeMounts:
     - mountPath: /bitnami/mariadb


### PR DESCRIPTION
This PR replaces the Mariadb image, created by Bitnami, to avoid Broadcome's rug pull distruption 