### PR TITLE
Audo deploy only on chart changes

### DIFF
--- a/.github/workflows/helmfile-cd.yml
+++ b/.github/workflows/helmfile-cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'helm/**'
+      - 'helmfile'
 
 jobs:
   deploy:


### PR DESCRIPTION
Not all repo's PRs are app deployment related so there're unnecessery workflow runs. This PR will limit the auto-deploy to only execute when any chart element change.