### PR TITLE
Use default k8s context

### DIFF
--- a/terraform/live/platform/dev/env.hcl
+++ b/terraform/live/platform/dev/env.hcl
@@ -1,7 +1,7 @@
 locals{
   kube = {
     config_path    = "~/.kube/dev-config"
-    config_context = "dev-ctx"
+    config_context = "default"
   }
 
   metallb = {

--- a/terraform/live/platform/staging/env.hcl
+++ b/terraform/live/platform/staging/env.hcl
@@ -1,7 +1,7 @@
 locals{
   kube = {
     config_path    = "~/.kube/staging-config"
-    config_context = "staging-ctx"
+    config_context = "default"
   }
 
   metallb = {


### PR DESCRIPTION
Since now we're using a separate kube config file for each cluster